### PR TITLE
[Feat] 온보딩에서 선택하지 않을 경우 다음 버튼 비활성화

### DIFF
--- a/ToGather/ToGather/Screens/FriendAddition/View/FriendAdditionView.swift
+++ b/ToGather/ToGather/Screens/FriendAddition/View/FriendAdditionView.swift
@@ -89,7 +89,6 @@ struct FriendAdditionView: View {
                         .cornerRadius(30)
                         .padding(.horizontal, 20)
                 })
-                .disabled(friendAdditionViewModel.isFriendEmpty())
                 .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
             } else {
                 Button {

--- a/ToGather/ToGather/Screens/FriendAddition/View/FriendAdditionView.swift
+++ b/ToGather/ToGather/Screens/FriendAddition/View/FriendAdditionView.swift
@@ -89,6 +89,7 @@ struct FriendAdditionView: View {
                         .cornerRadius(30)
                         .padding(.horizontal, 20)
                 })
+                .disabled(friendAdditionViewModel.isFriendEmpty())
                 .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
             } else {
                 Button {

--- a/ToGather/ToGather/Screens/GoalSetting/View/GoalSetting.swift
+++ b/ToGather/ToGather/Screens/GoalSetting/View/GoalSetting.swift
@@ -133,7 +133,7 @@ struct GoalSetting: View {
                         .cornerRadius(30)
                         .padding(.horizontal, 20)
                         
-                })
+                }).disabled(isSelectedItem == nil ? true : false)
             } // VStack
             .navigationBarHidden(true)
         } // NavigationView

--- a/ToGather/ToGather/Screens/SettingPeriod/SettingPeriod.swift
+++ b/ToGather/ToGather/Screens/SettingPeriod/SettingPeriod.swift
@@ -153,17 +153,17 @@ struct SettingPeriodView: View {
     }
 
     private var nextButton: some View {
-            return VStack {
-                CustomNavigationLink(destination: FriendAdditionView(onboardingViewModel: onboardingViewModel, isPresentationMode: $isPresentationMode).onAppear(perform: {
-                    guard let selectedDay = selectedDay else {
-                        return
-                    }
-                    userViewModel.addGoalWeekAndDayOfTheWeek(goalWeeks: goalWeek, dayOfTheWeek: selectedDay)
-                })) {
+        return VStack {
+            CustomNavigationLink(destination: FriendAdditionView(onboardingViewModel: onboardingViewModel, isPresentationMode: $isPresentationMode).onAppear(perform: {
+                guard let selectedDay = selectedDay else {
+                    return
+                }
+                userViewModel.addGoalWeekAndDayOfTheWeek(goalWeeks: goalWeek, dayOfTheWeek: selectedDay)
+            })) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 30)
                         .foregroundColor(selectedDay != nil ? Color.pointColor : Color.black03)
-                            .frame(width: 350, height: 46, alignment: .center)
+                        .frame(width: 350, height: 46, alignment: .center)
                     Text("다음").foregroundColor(.white)
                         .fontWeight(.semibold)
                 }

--- a/ToGather/ToGather/Screens/SettingPeriod/SettingPeriod.swift
+++ b/ToGather/ToGather/Screens/SettingPeriod/SettingPeriod.swift
@@ -167,7 +167,7 @@ struct SettingPeriodView: View {
                     Text("다음").foregroundColor(.white)
                         .fontWeight(.semibold)
                 }
-            }
+            }.disabled(selectedDay == nil ? true : false)
             Spacer(minLength: 36)
         }
     }


### PR DESCRIPTION
<!-- 비트 @yeongwooCho 랜스 @limhyoseok 밀러 @KimDaeSeong8721 닐 @yudonlee 맥스 @Sungwooo 이브@unuhqueen -->

<!-- 해당 PR과 관련된 이슈를 오른쪽 사이드 Development에 추가해주세요 -->

## 🍏 작업내용
<img width="780" alt="image" src="https://user-images.githubusercontent.com/59302419/181141225-3247381b-51a5-4b5b-8e1a-4f423b7c4616.png">

- 아이템 선택하지 않을 경우 다음 버튼 비활성화 (아래 뷰에 적용)
    - GoalSetting
    - SettingPeriod
    - FriendAdditionView
- SettingPeriod.swift에서 코드 들여쓰기 재정렬


## 🍏 다음으로 진행될 작업
 - [ ] 다음으로 할 일을 적어주세요.

## 🍏 질문
<!-- PR 과정에서 생긴 질문을 적어주세요. -->
