### PR TITLE
[Feat] 친구 사진정보 불러오기

### DIFF
--- a/ToGather/ToGather/Global/Service/FirebaseManager.swift
+++ b/ToGather/ToGather/Global/Service/FirebaseManager.swift
@@ -111,8 +111,8 @@ final class FirebaseManager: ObservableObject {
      }
     
     /// 인증사진들 가져오기
-    func requestAuthPics(userData: User, completion : @escaping ([String]) -> Void) {
-            
+    func requestAuthPics(userData: User, completion : @escaping (([String], [String])) -> Void) {
+        
         let db = Database.database().reference()
         print(db)
 
@@ -126,12 +126,14 @@ final class FirebaseManager: ObservableObject {
             let weekInfo = try decoder.decode([ThisWeek].self, from: data)
 
                 var authPics : [String] = []
+                var authPicsDate : [String] = []
                 for week in weekInfo {
-                    if let imageUrl = week.imageUrl {
-                    authPics.append(imageUrl)
+                    if let imageUrl = week.imageUrl, let date = week.date {
+                        authPics.append(imageUrl)
+                        authPicsDate.append(date)
                     }
                 }
-                completion(authPics)
+                completion((authPics, authPicsDate))
             } catch let DecodingError.dataCorrupted(context) {
                 print(context)
             } catch let DecodingError.keyNotFound(key, context) {

--- a/ToGather/ToGather/Global/Service/FirebaseManager.swift
+++ b/ToGather/ToGather/Global/Service/FirebaseManager.swift
@@ -226,8 +226,8 @@ final class FirebaseManager: ObservableObject {
     
     /// 친구 ID들 입력해서 User 데이터 한번에 가져오기
     /// - Parameters:
-    ///   - userIds: <#userIds description#>
-    ///   - completion: <#completion description#>
+    ///   - userIds: 친구들 ID Array
+    ///   - completion: ID에대한 User정보 반환
     func requestUsers(userIds:[String],completion: @escaping (([User]) -> Void)) {
         
         let db = Database.database().reference()

--- a/ToGather/ToGather/Global/Service/FirebaseManager.swift
+++ b/ToGather/ToGather/Global/Service/FirebaseManager.swift
@@ -111,7 +111,7 @@ final class FirebaseManager: ObservableObject {
      }
     
     /// 인증사진들 가져오기
-    func requestAuthPics(userData: User, completion : @escaping (([String], [String])) -> Void) {
+    func requestAuthPics(userData: User, completion : @escaping ((pics: [String], picsDate: [String])) -> Void) {
         
         let db = Database.database().reference()
         print(db)

--- a/ToGather/ToGather/Models/ThisWeek.swift
+++ b/ToGather/ToGather/Models/ThisWeek.swift
@@ -12,5 +12,6 @@ struct ThisWeek: Identifiable, Codable {
     let presentWeek: Int
     var didSave: Bool
     var imageUrl: String?
+    var date: String?
     var id: Int {presentWeek}
 }

--- a/ToGather/ToGather/Screens/Core/SavingRecord/View/SavingRecordView.swift
+++ b/ToGather/ToGather/Screens/Core/SavingRecord/View/SavingRecordView.swift
@@ -139,6 +139,7 @@ struct SavingRecordView: View {
                     return
                 }
                 userViewModel.userData.saveInfo.weekInfo[currentWeek - 1].didSave = true
+                userViewModel.userData.saveInfo.weekInfo[currentWeek - 1].date = dateToString(date: Date())
                 FirebaseManager.shared.uploadAuthPic(uiImage, to: userViewModel.userData)
                 userViewModel.requestAuthPics()
                 // image 파일이 존재할 때 Firebase에 쓰는 기능

--- a/ToGather/ToGather/Screens/Core/SavingStatus/View/SavingStatusView.swift
+++ b/ToGather/ToGather/Screens/Core/SavingStatus/View/SavingStatusView.swift
@@ -227,7 +227,7 @@ extension SavingStatusView {
                                 }
                             }
                         }
-                        Text("\(dummyImage[index].1)").foregroundColor(.basicBlack.opacity(0.6)).padding(EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 10))
+                        Text("\(userViewModel.authPicsDateDiff[index])").foregroundColor(.basicBlack.opacity(0.6)).padding(EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 10))
                     }
                 }
             }

--- a/ToGather/ToGather/Screens/Core/Start/ViewModel/OnboardingViewModel.swift
+++ b/ToGather/ToGather/Screens/Core/Start/ViewModel/OnboardingViewModel.swift
@@ -19,7 +19,8 @@ class OnBoardingViewModel: ObservableObject {
             UserDefaults.standard.set(true, forKey: "isNotFirstOn")
             self.isFirstOn = true
         } else {
-            self.isFirstOn = true
+            self.isFirstOn = false
+            
         }
     }
     /// 앱이 처음 구동되어 온보딩페이지에서 작동되다가,

--- a/ToGather/ToGather/Screens/Core/mainFriendSaving/FrSavingView.swift
+++ b/ToGather/ToGather/Screens/Core/mainFriendSaving/FrSavingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Kingfisher
 
 struct FrSavingStatusNavigationView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
@@ -43,6 +44,48 @@ struct FrSavingStatusView: View {
     var totalFailedNum: Int {user.saveInfo.totalFailedNum}
     var totalSavedNum: Int {user.saveInfo.totalSavedNum}
     var isDueExtended: Bool {totalFailedNum != 0 ? true : false}
+    
+    var authPics: [String] {
+        var result: [String] = []
+        user.saveInfo.weekInfo.forEach { thisWeek in
+            if let imageUrl = thisWeek.imageUrl {
+                result.append(imageUrl)
+            }
+        }
+        return result
+    }
+    
+    var authPicsDate: [String] {
+        var result: [String] = []
+        user.saveInfo.weekInfo.forEach { thisWeek in
+            if let date = thisWeek.date {
+                result.append(date)
+            }
+        }
+        return result
+    }
+    
+    var authPicsDateDiff: [String] {
+        let nowStr = dateToString(date: Date())
+        let currentDate = stringToDate(date: nowStr)
+        
+        var dateDiff: [String] = []
+        authPicsDate.forEach { element in
+            let created = stringToDate(date: element)
+            let diff = Calendar.current.dateComponents([.day, .weekOfYear], from: created, to: currentDate)
+            
+            if let week = diff.weekOfYear, let day = diff.day {
+                if week != 0 {
+                    dateDiff.append("\(week)주전")
+                } else {
+                    dateDiff.append(day == 0 ? "오늘" : "\(day)일전")
+                }
+            }
+            
+        }
+        
+        return dateDiff
+    }
     
     var isMine: Bool = true
     
@@ -151,13 +194,13 @@ extension FrSavingStatusView {
                 .foregroundColor(color)
             Spacer()
             
-            Button {
-                isPhotoEdited.toggle()
-            } label: {
-                Text( isPhotoEdited ? "편집 완료" : "사진 편집")
-                    .font(.system(size: 14))
-                    .foregroundColor(isPhotoEdited ? .black02 : .alertRed)
-            }
+//            Button {
+//                isPhotoEdited.toggle()
+//            } label: {
+//                Text( isPhotoEdited ? "편집 완료" : "사진 편집")
+//                    .font(.system(size: 14))
+//                    .foregroundColor(isPhotoEdited ? .black02 : .alertRed)
+//            }
             
         }
     }
@@ -165,10 +208,10 @@ extension FrSavingStatusView {
     var fRSuccessPictureGrid: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
-                ForEach(0..<dummyImage.count) { i in
+                ForEach(0..<authPics.count) { index in
                     VStack(alignment: .trailing) {
                         ZStack(alignment: .topTrailing) {
-                            Image(dummyImage[i].0)
+                            KFImage(URL(string: authPics[index]))
                                 .resizable()
                                 .aspectRatio(contentMode: .fill)
                                 .frame(width: 149, height: 239)
@@ -181,21 +224,21 @@ extension FrSavingStatusView {
                                 .background(.clear)
                                 .cornerRadius(8)
                                 .padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 10))
-                            if isPhotoEdited {
-                                ZStack(alignment: .topTrailing) {
-                                    Button {
-                                        dummyImage.remove(at: i)
-
-                                    } label: {
-                                        Image(systemName: "minus.circle.fill")
-                                            .foregroundColor(.red)
-                                        //                    .background()
-                                            .font(.system(size: 16))
-                                    }
-                                }
-                            }
+//                            if isPhotoEdited {
+//                                ZStack(alignment: .topTrailing) {
+//                                    Button {
+//                                        dummyImage.remove(at: i)
+//
+//                                    } label: {
+//                                        Image(systemName: "minus.circle.fill")
+//                                            .foregroundColor(.red)
+//                                        //                    .background()
+//                                            .font(.system(size: 16))
+//                                    }
+//                                }
+//                            }
                         }
-                        Text("\(dummyImage[i].1)").foregroundColor(.basicBlack.opacity(0.6)).padding(EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 10))
+                        Text("\(authPicsDateDiff[index])").foregroundColor(.basicBlack.opacity(0.6)).padding(EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 10))
                     }
                 }
             }

--- a/ToGather/ToGather/ViewModels/UserViewModel.swift
+++ b/ToGather/ToGather/ViewModels/UserViewModel.swift
@@ -17,6 +17,8 @@ final class UserViewModel: ObservableObject {
     @Published var dummyUserData = dummyFriend1
     
     @Published var authPics : [String] = []
+    @Published var authPicsDate: [String] = []
+    @Published var authPicsDateDiff: [String] = []
     
     @Published var friendNicknames: [String]  = []
     @Published var friendUids: [String] = []
@@ -57,8 +59,10 @@ final class UserViewModel: ObservableObject {
     
     ///유저 인증사진들 가져오기
     func requestAuthPics() {
-        FirebaseManager.shared.requestAuthPics(userData: userData) { authPics in
-            self.authPics = authPics
+        FirebaseManager.shared.requestAuthPics(userData: userData) { [weak self] result in
+            self?.authPics = result.0
+            self?.authPicsDate = result.1
+            self?.setImageDate()
         }
     }
 
@@ -85,6 +89,29 @@ final class UserViewModel: ObservableObject {
         self.initUid()
         self.uploadUserData()
         self.requestFriendProgressCircles()
+    }
+    
+    func setImageDate() {
+        let nowStr = dateToString(date: Date())
+        let currentDate = stringToDate(date: nowStr)
+        
+        var dateDiff: [String] = []
+        authPicsDate.forEach { element in
+            let created = stringToDate(date: element)
+            let diff = Calendar.current.dateComponents([.day, .weekOfYear], from: created, to: currentDate)
+            
+            if let week = diff.weekOfYear, let day = diff.day {
+                if week != 0 {
+                    dateDiff.append("\(week)주전")
+                } else {
+                    dateDiff.append(day == 0 ? "오늘" : "\(day)일전")
+                }
+            }
+            
+        }
+        
+        authPicsDateDiff = dateDiff
+        
     }
 }
 

--- a/ToGather/ToGather/ViewModels/UserViewModel.swift
+++ b/ToGather/ToGather/ViewModels/UserViewModel.swift
@@ -60,9 +60,9 @@ final class UserViewModel: ObservableObject {
     ///유저 인증사진들 가져오기
     func requestAuthPics() {
         FirebaseManager.shared.requestAuthPics(userData: userData) { [weak self] result in
-            self?.authPics = result.0
-            self?.authPicsDate = result.1
-            self?.setImageDate()
+            self?.authPics = result.pics
+            self?.authPicsDate = result.picsDate
+            self?.calculateImageDate()
         }
     }
 

--- a/ToGather/ToGather/ViewModels/UserViewModel.swift
+++ b/ToGather/ToGather/ViewModels/UserViewModel.swift
@@ -91,7 +91,7 @@ final class UserViewModel: ObservableObject {
         self.requestFriendProgressCircles()
     }
     
-    func setImageDate() {
+    func calculateImageDate() {
         let nowStr = dateToString(date: Date())
         let currentDate = stringToDate(date: nowStr)
         


### PR DESCRIPTION
<!-- 비트 @yeongwooCho 랜스 @limhyoseok 밀러 @KimDaeSeong8721 닐 @yudonlee 맥스 @Sungwooo 이브@unuhqueen -->

<!-- 해당 PR과 관련된 이슈를 오른쪽 사이드 Development에 추가해주세요 -->
## 🍏 작업내용
<img src= https://user-images.githubusercontent.com/39371835/184121891-93310692-6a1a-4c3b-9881-0535f57902c0.gif width = 200>
친구에 사진정보를 어떻게 불러올까 고민하다가, frSavingView의 computed property를 그대로 사용했습니다~

### 사용로직
user.saveInfo.weekInfo의 [ThisWeek]를 forEach로 iterate하면서 imageUrl과 date가 nil이 아닌걸 찾아내서 authPics, authPicsDate, authPicsDateDiff에 넣어주었습니다!

## 🍏 다음으로 진행될 작업
- [ ] finish!
<!-- - [ ] 다음으로 할 일을 적어주세요. -->

## 🍏 질문
해당 과정을 SavingStatusView에 그대로 적용하면 기존에 존재하는 FirebaseManager의 requestAuthPics를 삭제해도 될 것 같습니다. 
그래도 될까요?
<!-- PR 과정에서 생긴 질문을 적어주세요. -->
